### PR TITLE
Expand python example

### DIFF
--- a/D_mipi_rpi/python_demo/D_mipicamera.py
+++ b/D_mipi_rpi/python_demo/D_mipicamera.py
@@ -262,7 +262,7 @@ class mipi_camera(object):
     
     def __init__(self):
         self.camera_instance = c_void_p(0)
-    def init_camera(self, camera_interface=None):
+    def init_camera(self, camera_interface=None, format_=None):
         #//0or1 for CM
         cam_infe = CAMERA_INTERFACE(0,-1,(0,0),(0,0));
         if camera_interface is not None:
@@ -271,8 +271,15 @@ class mipi_camera(object):
             except (TypeError, ValueError) as e:
                 raise TypeError(
                     "Invalid camera_interface " )
+        if format_ is None:
+            frmt = FORMAT(1920, 1080, 30)
+        else:
+            try:
+                frmt = FORMAT(format_[0], format_[1], format_[2])
+            except (TypeError, ValueError, IndexError) as e:
+                raise TypeError("Invalid camera format " )
         check_status(
-            D_init_camera(byref(self.camera_instance), cam_infe),
+            D_init_camera_ex(byref(self.camera_instance), cam_infe, frmt),
             sys._getframe().f_code.co_name
         )
     def start_preview(self, fullscreen = True, opacity = 255, window = None):

--- a/D_mipi_rpi/python_demo/capture2opencv.py
+++ b/D_mipi_rpi/python_demo/capture2opencv.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import D_mipicamera as Dcam
 import time
 import cv2 #sudo apt-get install python-opencv
@@ -8,15 +10,18 @@ def align_down(size, align):
 def align_up(size, align):
     return align_down(size + align - 1, align)
 
+WIDTH = 1280
+HEIGHT = 720
+
 if __name__ == "__main__":
     try:
         camera = Dcam.mipi_camera()
         print("Open camera...")
-        camera.init_camera()
+        camera.init_camera(format_=(WIDTH, HEIGHT, 30))
         while cv2.waitKey(10) != 27:
             frame = camera.capture(encoding = 'i420')
-            height = int(align_up(1080, 16))
-            width = int(align_up(1920, 32))
+            height = int(align_up(HEIGHT, 16))
+            width = int(align_up(WIDTH, 32))
             image = frame.as_array.reshape(int(height * 1.5), width)
             image = cv2.cvtColor(image, cv2.COLOR_YUV2BGR_I420)
             cv2.imshow("D-Cam", image)


### PR DESCRIPTION
I think this is how from opencv one can use a different resolution and framerate. The default behavior of the example is unchanged, as 1920x1080 at 30fps is the default.